### PR TITLE
bug: kids array can be empty

### DIFF
--- a/src/main/scala/fs2/pdf/Element.scala
+++ b/src/main/scala/fs2/pdf/Element.scala
@@ -1,7 +1,6 @@
 package fs2
 package pdf
 
-import cats.data.NonEmptyList
 import cats.effect.IO
 import scodec.Attempt
 import scodec.bits.{BitVector, ByteVector}
@@ -47,7 +46,7 @@ object Page
   * @param kids children of this Pages object, forming a balanced tree with page numbers going left-to-right
   * @param root whether this object is the root referenced in the trailer
   */
-case class Pages(index: Obj.Index, data: Prim.Dict, kids: NonEmptyList[Prim.Ref], root: Boolean)
+case class Pages(index: Obj.Index, data: Prim.Dict, kids: List[Prim.Ref], root: Boolean)
 
 /**
   * Helpers for extracting a [[Pages]] record from an [[IndirectObj]] or its components.

--- a/src/main/scala/fs2/pdf/Pdf.scala
+++ b/src/main/scala/fs2/pdf/Pdf.scala
@@ -49,7 +49,7 @@ object Pdf
       .through(PdfStream.elements(Log.noop))
       .collect {
         case Element.Data(_, Element.DataKind.Pages(Pages(_, _, kids, _))) =>
-          kids.toList.lift(page).map(_.number)
+          kids.lift(page).map(_.number)
       }
       .collect { case Some(a) => a }
       .head

--- a/src/main/scala/fs2/pdf/Prim.scala
+++ b/src/main/scala/fs2/pdf/Prim.scala
@@ -249,7 +249,7 @@ extends PrimCodec
           elems.collect {
             case r@Ref(_, _) => Some(r)
             case _ => None
-          }.traverse(identity)
+          }.sequence
         case _ =>
           None
       }

--- a/src/main/scala/fs2/pdf/Prim.scala
+++ b/src/main/scala/fs2/pdf/Prim.scala
@@ -3,7 +3,6 @@ package pdf
 
 import scala.util.Try
 
-import cats.data.NonEmptyList
 import cats.implicits._
 import codec.{Codecs, Many, Text, Whitespace}
 import scodec.{Attempt, Codec, DecodeResult, Decoder, Encoder, Err}
@@ -243,18 +242,14 @@ extends PrimCodec
       tryDict("Linearized")(data).isDefined
   }
 
-  object refs
-  {
-    def unapply(data: Prim): Option[NonEmptyList[Ref]] =
+  object refs {
+    def unapply(data: Prim): Option[List[Ref]] =
       data match {
         case Prim.Array(elems) =>
-          NonEmptyList.fromList(elems)
-            .flatMap(
-              _.traverse {
-                case r @ Ref(_, _) => Some(r)
-                case _ => None
-              }
-            )
+          elems.collect {
+            case r@Ref(_, _) => Some(r)
+            case _ => None
+          }.traverse(identity)
         case _ =>
           None
       }

--- a/src/main/scala/fs2/pdf/ValidatePdf.scala
+++ b/src/main/scala/fs2/pdf/ValidatePdf.scala
@@ -127,8 +127,8 @@ object ValidatePdf
       }
     spin(root).andThen {
       case (_, Nil) => Validated.invalidNel(PdfError.NoPages)
-      case (page1, pages1 :: pagestail) =>
-        Validated.valid((page1, NonEmptyList(pages1, pagestail)))
+      case (page1s, pages1 :: pagestail) =>
+        Validated.valid((page1s, NonEmptyList(pages1, pagestail)))
     }
   }
 

--- a/src/main/scala/fs2/pdf/ValidatePdf.scala
+++ b/src/main/scala/fs2/pdf/ValidatePdf.scala
@@ -36,9 +36,6 @@ object PdfError
   case object NoPages
   extends PdfError
 
-  case object EmptyPages
-  extends PdfError
-
   case object NoRoot
   extends PdfError
 
@@ -64,8 +61,6 @@ object PdfError
       s"object $obj is neither Pages nor Page"
     case NoPages =>
       "no Pages objects in the catalog"
-    case EmptyPages =>
-      "no Page objects in a page tree"
     case NoRoot =>
       "no Root in trailer"
     case NoCatalog =>
@@ -116,7 +111,7 @@ object ValidatePdf
   }
 
   def collectPages(byNumber: Map[Long, IndirectObj])(root: IndirectObj)
-  : ValidatedNel[PdfError, (NonEmptyList[Page], NonEmptyList[Pages])] = {
+  : ValidatedNel[PdfError, (List[Page], NonEmptyList[Pages])] = {
     def spin(obj: IndirectObj): ValidatedNel[PdfError, (List[Page], List[Pages])] =
       obj match {
         case Pages.obj(pages @ Pages(_, _, kids, _)) =>
@@ -132,9 +127,8 @@ object ValidatePdf
       }
     spin(root).andThen {
       case (_, Nil) => Validated.invalidNel(PdfError.NoPages)
-      case (Nil, _) => Validated.invalidNel(PdfError.EmptyPages)
-      case (page1 :: pagetail, pages1 :: pagestail) =>
-        Validated.valid((NonEmptyList(page1, pagetail), NonEmptyList(pages1, pagestail)))
+      case (page1, pages1 :: pagestail) =>
+        Validated.valid((page1, NonEmptyList(pages1, pagestail)))
     }
   }
 

--- a/src/test/resources/empty-kids.pdf
+++ b/src/test/resources/empty-kids.pdf
@@ -1,0 +1,107 @@
+%PDF-1.7
+%âãÏÓ
+1 0 obj
+<<
+/Resources 6 0 R
+/Parent 3 0 R
+/Contents 5 0 R
+/MediaBox [0 0 600 800 ]
+/Type /Page
+/Annots [10 0 R ]
+>>
+endobj
+2 0 obj
+<<
+/Resources 6 0 R
+/Parent 3 0 R
+/Contents 5 0 R
+/MediaBox [0 0 600 800 ]
+/Type /Page
+/Annots [10 0 R ]
+>>
+endobj
+3 0 obj
+<<
+/Type /Pages
+/Count 0
+/Kids []
+>>
+endobj
+4 0 obj
+<<
+/Type /Catalog
+/Pages 3 0 R
+/Outlines 8 0 R
+>>
+endobj
+5 0 obj
+<<
+/Length 48
+>>
+stream
+BT
+  /F1 24 Tf
+  50 750 Td
+  (Hello World) Tj
+ET
+endstream
+endobj
+6 0 obj
+<<
+/ProcSet [/PDF /Text ]
+/Font <<
+/F1 7 0 R
+>>
+>>
+endobj
+7 0 obj
+<<
+/BaseFont /Helvetica
+/Name /F1
+/Encoding /MacRomanEncoding
+/Subtype /Type1
+/Type /Font
+>>
+endobj
+8 0 obj
+<<
+/Type /Outlines
+/Count 0
+>>
+endobj
+9 0 obj
+<<
+>>
+endobj
+10 0 obj
+<<
+/Border [0 0 0 ]
+/Contents (the annotation)
+/Rect [200 50 400 150 ]
+/Subtype /FreeText
+/Type /Annot
+>>
+endobj
+xref
+0 11
+0000000000 65535 f 
+0000000019 00000 n 
+0000000142 00000 n 
+0000000265 00000 n 
+0000000317 00000 n 
+0000000382 00000 n 
+0000000480 00000 n 
+0000000546 00000 n 
+0000000654 00000 n 
+0000000700 00000 n 
+0000000721 00000 n 
+trailer
+<<
+/Size 11
+/Root 4 0 R
+/Id [<FF1FE073E0365E226E145B0CC9CB0758> <FF1FE073E0365E226E145B0CC9CB0758> ]
+/Info 9 0 R
+>>
+startxref
+843
+%%EOF

--- a/src/test/scala/fs2/pdf/RewriteTest.scala
+++ b/src/test/scala/fs2/pdf/RewriteTest.scala
@@ -16,4 +16,9 @@ extends Specification
   ProcessJarPdf.ignoreError(ProcessJarPdf.processWith("books/comm")(pipe))
     .unsafeRunSync
     .must_==(())
+
+  "parse pdf with empty kids" >>
+    ProcessJarPdf.ignoreError(ProcessJarPdf.processWith("empty-kids")(pipe))
+      .unsafeRunSync
+      .must_==(())
 }

--- a/src/test/scala/fs2/pdf/ValidatePdfTest.scala
+++ b/src/test/scala/fs2/pdf/ValidatePdfTest.scala
@@ -24,4 +24,8 @@ extends Specification
 
   // "validate" >>
   // ProcessJarPdf.processWithIO("books/broken-comm")(PdfStream.validate).value.map(a => a.must(beRight(beValid))).unsafeRunSync
+
+  "validate empty kids" >>
+    ProcessJarPdf.processWithIO("empty-kids")(PdfStream.validate)
+      .value.map(a => a.must(beRight(beValid))).unsafeRunSync
 }


### PR DESCRIPTION
The Kids array is required:
https://www.oreilly.com/library/view/pdf-explained/9781449321581/ch04.html

But as in the definition of array objects - it can be empty:
https://www.oreilly.com/library/view/developing-with-pdf/9781449327903/ch01.html